### PR TITLE
Fix to solve scrapy utf-8 encoding errors while crawling

### DIFF
--- a/webcorpus/crawlers/settings.py
+++ b/webcorpus/crawlers/settings.py
@@ -17,6 +17,8 @@ DOWNLOAD_TIMEOUT = 60
 RETRY_ENABLED = True
 RETRY_TIMES = 2     # + initial request
 
+FEED_EXPORT_ENCODING = 'utf-8'
+
 
 LOG_LEVEL = 'DEBUG'
 


### PR DESCRIPTION
```python
2021-11-23 03:55:17 [scrapy.core.scraper] ERROR: Spider error processing <GET https://www.bodoinfo.com/feeds/8902085308058657131/comments/default> (referer: https://www.bodoinfo.com/2021/08/how-kings-queens-cloths-were-clean-in-old-time.html)
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/scrapy/utils/defer.py", line 120, in iter_errback
    yield next(it)
  File "/usr/local/lib/python3.6/dist-packages/scrapy/utils/python.py", line 353, in __next__
    return next(self.data)
  File "/usr/local/lib/python3.6/dist-packages/scrapy/utils/python.py", line 353, in __next__
    return next(self.data)
  File "/usr/local/lib/python3.6/dist-packages/scrapy/core/spidermw.py", line 62, in _evaluate_iterable
    for r in iterable:
  File "/usr/local/lib/python3.6/dist-packages/scrapy/spidermiddlewares/offsite.py", line 29, in process_spider_output
    for x in result:
  File "/usr/local/lib/python3.6/dist-packages/scrapy/core/spidermw.py", line 62, in _evaluate_iterable
    for r in iterable:
  File "/usr/local/lib/python3.6/dist-packages/scrapy/spidermiddlewares/referer.py", line 340, in <genexpr>
    return (_set_referer(r) for r in result or ())
  File "/usr/local/lib/python3.6/dist-packages/scrapy/core/spidermw.py", line 62, in _evaluate_iterable
    for r in iterable:
  File "/usr/local/lib/python3.6/dist-packages/scrapy/spidermiddlewares/urllength.py", line 37, in <genexpr>
    return (r for r in result or () if _filter(r))
  File "/usr/local/lib/python3.6/dist-packages/scrapy/core/spidermw.py", line 62, in _evaluate_iterable
    for r in iterable:
  File "/usr/local/lib/python3.6/dist-packages/scrapy/spidermiddlewares/depth.py", line 58, in <genexpr>
    return (r for r in result or () if _filter(r))
  File "/usr/local/lib/python3.6/dist-packages/scrapy/core/spidermw.py", line 62, in _evaluate_iterable
    for r in iterable:
  File "/home/gowtham_ramesh1/webcorpus/webcorpus/crawlers/news.py", line 125, in parse
    self.write_html(response)
  File "/home/gowtham_ramesh1/webcorpus/webcorpus/crawlers/news.py", line 83, in write_html
    html = self.cleaner.clean_html(response.text)
  File "src/lxml/html/clean.py", line 555, in lxml.html.clean.Cleaner.clean_html
  File "/usr/local/lib/python3.6/dist-packages/lxml/html/__init__.py", line 875, in fromstring
    doc = document_fromstring(html, parser=parser, base_url=base_url, **kw)
  File "/usr/local/lib/python3.6/dist-packages/lxml/html/__init__.py", line 761, in document_fromstring
    value = etree.fromstring(html, parser, **kw)
  File "src/lxml/etree.pyx", line 3237, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1891, in lxml.etree._parseMemoryDocument
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
```